### PR TITLE
feat: add confirmations parameter to transaction receipts in Morpho service

### DIFF
--- a/src/plugins/plugin-morpho/src/services/morphoService.ts
+++ b/src/plugins/plugin-morpho/src/services/morphoService.ts
@@ -237,6 +237,7 @@ export class MorphoService extends Service {
             hash,
             pollingInterval: 2_000,
             timeout: 120_000,
+            confirmations: 2,
           });
           console.log(
             `${label} -> mined. blockNumber=${receipt.blockNumber} status=${receipt.status}`
@@ -317,6 +318,7 @@ export class MorphoService extends Service {
             hash,
             pollingInterval: 2_000,
             timeout: 120_000,
+            confirmations: 2,
           });
           console.log(
             `${label} -> mined. blockNumber=${receipt.blockNumber} status=${receipt.status}`
@@ -403,6 +405,7 @@ export class MorphoService extends Service {
             hash,
             pollingInterval: 2_000,
             timeout: 120_000,
+            confirmations: 2,
           });
           console.log(
             `${label} -> mined. blockNumber=${receipt.blockNumber} status=${receipt.status}`
@@ -495,6 +498,7 @@ export class MorphoService extends Service {
             hash,
             pollingInterval: 2_000,
             timeout: 120_000,
+            confirmations: 2,
           });
           console.log(
             `${label} -> mined. blockNumber=${receipt.blockNumber} status=${receipt.status}`
@@ -587,6 +591,7 @@ export class MorphoService extends Service {
             hash,
             pollingInterval: 2_000,
             timeout: 120_000,
+            confirmations: 2,
           });
           console.log(
             `${label} -> mined. blockNumber=${receipt.blockNumber} status=${receipt.status}`
@@ -674,6 +679,7 @@ export class MorphoService extends Service {
             hash,
             pollingInterval: 2_000,
             timeout: 120_000,
+            confirmations: 2,
           });
           console.log(
             `${label} -> mined. blockNumber=${receipt.blockNumber} status=${receipt.status}`
@@ -1812,6 +1818,7 @@ export class MorphoService extends Service {
             hash,
             pollingInterval: 2_000,
             timeout: 120_000,
+            confirmations: 2,
           });
           console.log(
             `${label} -> mined. blockNumber=${receipt.blockNumber} status=${receipt.status}`
@@ -1893,6 +1900,7 @@ export class MorphoService extends Service {
             hash,
             pollingInterval: 2_000,
             timeout: 120_000,
+            confirmations: 2,
           });
           console.log(
             `${label} -> mined. blockNumber=${receipt.blockNumber} status=${receipt.status}`


### PR DESCRIPTION
## Summary

This PR adds  parameter to all  calls in the Morpho service to improve transaction reliability.

## Changes

- Added  to 8 different  calls throughout the MorphoService class
- This ensures transactions wait for 2 block confirmations before being considered final
- Reduces the risk of transaction reorg issues

## Benefits

- Improved transaction reliability
- Reduced risk of blockchain reorganization affecting confirmed transactions
- More robust handling of transaction finality

## Files Modified

- 

## Testing

- [ ] Existing tests should continue to pass
- [ ] Manual testing of transaction confirmations (if applicable)